### PR TITLE
fixed alignment in mobile devices

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -458,6 +458,10 @@ h2 {
 	.card {
 		margin-bottom: 1em;
 	}
+
+	.card-desc {
+		text-align: center;
+	}
 	.page-header:after {
 		margin: 0.5em auto 0 auto;
 		height: 2px;
@@ -472,6 +476,7 @@ h2 {
 		font-weight: 700;
 		font-size: 77%;
 		padding: 15px 27px;
+		text-align: center;
 	}
 
 	.horizontal {


### PR DESCRIPTION
# Why this PR? 
As part of the recommendation by the mentor to align the card description text on mobile. 

Screenshots: 
+ before: 
![image](https://user-images.githubusercontent.com/25581792/84385011-c9853700-abe6-11ea-952d-cb001453451d.png)
+ after: 
![image](https://user-images.githubusercontent.com/25581792/84385107-ea4d8c80-abe6-11ea-8601-93657adaf83f.png)

+ before : 
![image](https://user-images.githubusercontent.com/25581792/84385209-15d07700-abe7-11ea-9fe0-50905bd46bd9.png)
+ after 
![image](https://user-images.githubusercontent.com/25581792/84385245-25e85680-abe7-11ea-90a4-c4a1ead942f3.png)


